### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,32 @@
+# Documentation Index
+
+- [](&)Documentation/AccessibilityAPI.md
+- [](&)Documentation/AccessibilityGuide.md
+- [](&)Documentation/AdvancedGesturesAPI.md
+- [](&)Documentation/AdvancedGesturesGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/API/GestureRecognizers.md
+- [](&)Documentation/APIReference.md
+- [](&)Documentation/BasicGesturesAPI.md
+- [](&)Documentation/BasicGesturesGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/CustomGesturesAPI.md
+- [](&)Documentation/CustomGesturesGuide.md
+- [](&)Documentation/GestureBestPracticesGuide.md
+- [](&)Documentation/GestureEngine.md
+- [](&)Documentation/GestureLibraryManagerAPI.md
+- [](&)Documentation/GestureTrainingAPI.md
+- [](&)Documentation/GestureTrainingGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Guides/GettingStarted.md
+- [](&)Documentation/HapticFeedback.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/Migration.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/SwiftUIIntegration.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/Tutorials/AdvancedGestures.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,13 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AccessibilityExamples/AccessibilityGestureExample.swift
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedGestureExample.swift
+- ``Examples/AdvancedGestures/AdvancedGestureExample.swift
+- ``Examples/AdvancedGesturesExamples/AdvancedGestureExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicGestureExample.swift
+- ``Examples/BasicGestures/BasicGestureExample.swift
+- ``Examples/BasicGesturesExamples/BasicGestureExample.swift
+- ``Examples/CustomGesturesExamples/CustomGestureExample.swift
+- ``Examples/TrainingExamples/GestureTrainingExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.